### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -18,6 +20,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -25,3 +29,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[docker] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request updates the Dependabot configuration to introduce a cooldown period for automated dependency updates. This helps to reduce noise by spacing out pull requests for each ecosystem.

Configuration changes:

* Added a `cooldown` section with `default-days: 7` to the `gomod`, `github-actions`, and `docker` package ecosystems in `.github/dependabot.yml`, ensuring that Dependabot will wait 7 days between opening new pull requests for each ecosystem.