### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change ensures that the `post-merge.yml` workflow will also run when a tag is pushed, in addition to the existing triggers on the `main` and `release-*` branches.

* [`.github/workflows/post-merge.yml`](diffhunk://#diff-649dadd84b5d9938ac7f7a33a4020062fa437edcfc320554adf8bcf62c14602aR11-R12): Added a trigger so that the workflow runs on all tag pushes.