### PR TITLE
Update post-merge.yml to remove trigger on tag

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - main
       - release-*
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration. The workflow will no longer be triggered by new tags being pushed; it will only run on changes to the main and release-* branches or when manually dispatched.